### PR TITLE
Native apps, add CustomSchemeBrowser

### DIFF
--- a/Packages/com.cdm.authentication/Runtime/Browser/CustomSchemeBrowser.cs
+++ b/Packages/com.cdm.authentication/Runtime/Browser/CustomSchemeBrowser.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Cdm.Authentication.Browser
+{
+    /// <summary>
+    /// OAuth 2.0 verification browser that runs a local server and waits for a call with
+    /// the authorization verification code throught a custom scheme instead of a http listener
+    /// </summary>
+    public class CustomSchemeBrowser : IBrowser
+    {
+        private TaskCompletionSource<BrowserResult> _taskCompletionSource;
+
+        public async Task<BrowserResult> StartAsync(string loginUrl, string redirectUrl, CancellationToken cancellationToken = default)
+        {
+            _taskCompletionSource = new TaskCompletionSource<BrowserResult>();
+
+            cancellationToken.Register(() =>
+            {
+                _taskCompletionSource?.TrySetCanceled();
+            });
+
+            Application.deepLinkActivated += onDeepLinkActivated;
+
+            try
+            {
+                Application.OpenURL(loginUrl);
+                return await _taskCompletionSource.Task;
+            }
+            finally
+            {
+                Application.deepLinkActivated -= onDeepLinkActivated;
+            }
+        }
+
+        private void onDeepLinkActivated(string url)
+        {
+            _taskCompletionSource.SetResult(
+                new BrowserResult(BrowserStatus.Success, url));
+        }
+    }
+}

--- a/Packages/com.cdm.authentication/Runtime/Browser/CustomSchemeBrowser.cs
+++ b/Packages/com.cdm.authentication/Runtime/Browser/CustomSchemeBrowser.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 namespace Cdm.Authentication.Browser
 {
     /// <summary>
-    /// OAuth 2.0 verification browser that runs a local server and waits for a call with
-    /// the authorization verification code throught a custom scheme instead of a http listener
+    /// OAuth 2.0 verification browser that waits for a call with
+    /// the authorization verification code throught a custom scheme (aka protocol)
     /// </summary>
     public class CustomSchemeBrowser : IBrowser
     {

--- a/Packages/com.cdm.authentication/Runtime/Browser/CustomSchemeBrowser.cs.meta
+++ b/Packages/com.cdm.authentication/Runtime/Browser/CustomSchemeBrowser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 038d0344528c14d408d0fb43a7ab8735
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Summary
Sometimes, the redirect url is not a http url. Instead, a custom scheme is used
In that case, you don't have a httplistener listening on a http://localhost/, you might have a redirect_url my-app://login instead. You listen the flow callback by Application.deepLinkActivated and continue the flow from there

### See
https://www.oauth.com/oauth2-servers/redirect-uris/redirect-uris-native-apps/
https://docs.unity3d.com/Manual/deep-linking.html

### Test
Tested on hololens 2 with custom scheme (aka protocol)

### Naming
I am not totally sure about the class name, feel free to change it or suggest a better one