### PR TITLE
Make .NET Standard 2.0 compatible

### DIFF
--- a/Packages/com.cdm.authentication/Runtime/Browser/ASWebAuthenticationSessionBrowser.cs
+++ b/Packages/com.cdm.authentication/Runtime/Browser/ASWebAuthenticationSessionBrowser.cs
@@ -29,7 +29,7 @@ namespace Cdm.Authentication.Browser
             _taskCompletionSource = new TaskCompletionSource<BrowserResult>();
             
             // Discard URL parameters. They are not valid for iOS URL Scheme.
-            redirectUrl = redirectUrl.Split(':', StringSplitOptions.RemoveEmptyEntries)[0];
+            redirectUrl = redirectUrl.Split(new char[] {':'}, StringSplitOptions.RemoveEmptyEntries)[0];
             
             using var authenticationSession =
                 new ASWebAuthenticationSession(loginUrl, redirectUrl, AuthenticationSessionCompletionHandler);

--- a/Packages/com.cdm.authentication/Runtime/Browser/StandaloneBrowser.cs
+++ b/Packages/com.cdm.authentication/Runtime/Browser/StandaloneBrowser.cs
@@ -76,7 +76,7 @@ namespace Cdm.Authentication.Browser
         /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.net.httplistener?view=net-7.0#remarks" />
         private string AddForwardSlashIfNecessary(string url)
         {
-            char forwardSlash = '/';
+            string forwardSlash = "/";
             if (!url.EndsWith(forwardSlash))
             {
                 url += forwardSlash;

--- a/Packages/com.cdm.authentication/Runtime/Browser/WKWebViewAuthenticationSessionBrowser.cs
+++ b/Packages/com.cdm.authentication/Runtime/Browser/WKWebViewAuthenticationSessionBrowser.cs
@@ -20,7 +20,7 @@ namespace Cdm.Authentication.Browser
             _taskCompletionSource = new TaskCompletionSource<BrowserResult>();
 
             // Discard URL parameters. They are not valid for iOS URL Scheme.
-            redirectUrl = redirectUrl.Split(':', StringSplitOptions.RemoveEmptyEntries)[0];
+            redirectUrl = redirectUrl.Split(new char[] {':'}, StringSplitOptions.RemoveEmptyEntries)[0];
 
             using var authenticationSession =
                 new WKWebViewAuthenticationSession(loginUrl, redirectUrl, AuthenticationSessionCompletionHandler);


### PR DESCRIPTION
Make the code compatible with .NET standard 2.0, and therefore with Unity 2020.

### Summary
There are a few string functions only available in .NET standard 2.1. 


I've modified them with 2.0 available methods. They are less clean, but I think it is worth making the code compatible with the whole 2020 family by changing them.

### The 2.1 methods
https://learn.microsoft.com/en-us/dotnet/api/system.string.split?view=net-7.0#system-string-split(system-char-system-stringsplitoptions)
https://learn.microsoft.com/en-us/dotnet/api/system.string.endswith?view=net-7.0

### Test
```csharp
using System;
					
public class Program
{
	public static void Main()
	{
		string redirectUrl = "my-app://login/whatever";
		string redirectUrl1 = redirectUrl.Split(':', StringSplitOptions.RemoveEmptyEntries)[0]; //2.1 version
		string redirectUrl2 = redirectUrl.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries)[0]; //2.0 version
		Console.WriteLine(redirectUrl1); //output: my-app
		Console.WriteLine(redirectUrl2); //output: my-app
	}
}
````
